### PR TITLE
update river guide userdata script with oidc changes

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -81,6 +81,7 @@ output "river_guide_template" {
       background_color = var.river_guide_template_background_color,
       accent_color     = var.river_guide_template_accent_color,
       region           = var.river_guide_template_region,
+      port             = var.river_guide_template_port,
       oidc_config      = var.river_guide_template_oidc,
     }
   )

--- a/output.tf
+++ b/output.tf
@@ -76,10 +76,12 @@ output "river_guide_template" {
   value = templatefile(
     "${path.module}/templates/river_guide.sh.tftpl",
     {
-      tags   = var.river_guide_template_tags,
-      title  = var.river_guide_template_title,
-      color  = var.river_guide_template_color,
-      region = var.river_guide_template_region,
+      tags             = var.river_guide_template_tags,
+      title            = var.river_guide_template_title,
+      background_color = var.river_guide_template_background_color,
+      accent_color     = var.river_guide_template_accent_color,
+      region           = var.river_guide_template_region,
+      oidc_config      = var.river_guide_template_oidc,
     }
   )
 }

--- a/templates/base.sh.tftpl
+++ b/templates/base.sh.tftpl
@@ -16,7 +16,7 @@ fi
 # Install AWS CLI if necessary
 if ! command -v aws > /dev/null; then
   echo "The AWS CLI is not installed. Installing..."
-  curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -i).zip" -o "awscliv2.zip"
+  curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"
   unzip awscliv2.zip
   ./aws/install
   rm -rfv aws*

--- a/templates/mssql_server.sh.tftpl
+++ b/templates/mssql_server.sh.tftpl
@@ -1,9 +1,9 @@
 # Install MSSQL
 set -x
-curl -o /etc/yum.repos.d/mssql-server.repo https://packages.microsoft.com/config/rhel/8/mssql-server-2022.repo
+curl -o /etc/yum.repos.d/mssql-server.repo https://packages.microsoft.com/config/rhel/9/mssql-server-2022.repo
 yum install -y mssql-server
 MSSQL_PID=Developer ACCEPT_EULA=Y MSSQL_SA_PASSWORD='${password}' /opt/mssql/bin/mssql-conf -n setup
-curl -o /etc/yum.repos.d/msprod.repo https://packages.microsoft.com/config/rhel/8/prod.repo
+curl -o /etc/yum.repos.d/msprod.repo https://packages.microsoft.com/config/rhel/9/prod.repo
 ACCEPT_EULA=Y yum install -y mssql-tools unixODBC-devel
 echo '#!/bin/bash' > /etc/profile.d/mssql.sh
 # shellcheck disable=SC2016

--- a/templates/mssql_server.sh.tftpl
+++ b/templates/mssql_server.sh.tftpl
@@ -1,9 +1,10 @@
 # Install MSSQL
 set -x
-curl -o /etc/yum.repos.d/mssql-server.repo https://packages.microsoft.com/config/rhel/9/mssql-server-2022.repo
+RHEL_VERSION=$(rpm --eval '%rhel')
+curl -o /etc/yum.repos.d/mssql-server.repo https://packages.microsoft.com/config/rhel/$RHEL_VERSION/mssql-server-2022.repo
 yum install -y mssql-server
 MSSQL_PID=Developer ACCEPT_EULA=Y MSSQL_SA_PASSWORD='${password}' /opt/mssql/bin/mssql-conf -n setup
-curl -o /etc/yum.repos.d/msprod.repo https://packages.microsoft.com/config/rhel/9/prod.repo
+curl -o /etc/yum.repos.d/msprod.repo https://packages.microsoft.com/config/rhel/$RHEL_VERSION/prod.repo
 ACCEPT_EULA=Y yum install -y mssql-tools unixODBC-devel
 echo '#!/bin/bash' > /etc/profile.d/mssql.sh
 # shellcheck disable=SC2016

--- a/templates/river_guide.sh.tftpl
+++ b/templates/river_guide.sh.tftpl
@@ -8,7 +8,7 @@ fi
 curl -L https://github.com/frgrisk/river-guide/releases/download/v0.3.0/river-guide-linux-$GOARCH --output /opt/river-guide
 chmod 755 /opt/river-guide
 echo "export RIVER_GUIDE_OIDC_CLIENT_SECRET='${oidc_config.client_secret}'" >> ~/.bashrc
-echo "@reboot root . ~/.bashrc AWS_REGION=${region} /opt/river-guide %{if tags != null}--tags ${tags} %{endif}--title '${title}' \
+echo "@reboot root . ~/.bashrc && AWS_REGION=${region} /opt/river-guide %{if tags != null}--tags ${tags} %{endif}--title '${title}' \
 --background-color='${background_color}' \
 --accent-color='${accent_color}' \
 %{ if oidc_config != null ~}

--- a/templates/river_guide.sh.tftpl
+++ b/templates/river_guide.sh.tftpl
@@ -15,9 +15,15 @@ echo "@reboot root AWS_REGION=${region} /opt/river-guide %{if tags != null}--tag
 --oidc-client-id='${oidc_config.client_id}' \
 --oidc-client-secret='${oidc_config.client_secret}' \
 --oidc-redirect-url='${oidc_config.redirect_url}' \
-%{ if oidc_config.groups != null ~}--oidc-groups='${oidc_config.groups}' \%{ endif ~}
-%{ if oidc_config.scopes != null ~}--oidc-scopes='${oidc_config.scopes}' \%{ endif ~}
-%{ if oidc_config.log_claims != null ~}--oidc-log-claims='${oidc_config.log_claims}' \%{ endif ~}
+%{ if oidc_config.groups != null ~}
+--oidc-groups='${oidc_config.groups}' \
+%{ endif ~}
+%{ if oidc_config.scopes != null ~}
+--oidc-scopes='${oidc_config.scopes}' \
+%{ endif ~}
+%{ if oidc_config.log_claims != null ~}
+--oidc-log-claims='${oidc_config.log_claims}' \
+%{ endif ~}
 %{ endif ~}" \
 | tee -a /etc/crontab > /dev/null
 

--- a/templates/river_guide.sh.tftpl
+++ b/templates/river_guide.sh.tftpl
@@ -7,13 +7,13 @@ else
 fi
 curl -L https://github.com/frgrisk/river-guide/releases/download/v0.3.0/river-guide-linux-$GOARCH --output /opt/river-guide
 chmod 755 /opt/river-guide
-echo "@reboot root AWS_REGION=${region} /opt/river-guide %{if tags != null}--tags ${tags} %{endif}--title '${title}' \
+echo "export RIVER_GUIDE_OIDC_CLIENT_SECRET='${oidc_config.client_secret}'" >> ~/.bashrc
+echo "@reboot root . ~/.bashrc AWS_REGION=${region} /opt/river-guide %{if tags != null}--tags ${tags} %{endif}--title '${title}' \
 --background-color='${background_color}' \
 --accent-color='${accent_color}' \
 %{ if oidc_config != null ~}
 --oidc-issuer='${oidc_config.issuer}' \
 --oidc-client-id='${oidc_config.client_id}' \
---oidc-client-secret='${oidc_config.client_secret}' \
 --oidc-redirect-url='${oidc_config.redirect_url}' \
 %{ if oidc_config.groups != null ~}
 --oidc-groups='${oidc_config.groups}' \

--- a/templates/river_guide.sh.tftpl
+++ b/templates/river_guide.sh.tftpl
@@ -11,6 +11,7 @@ echo "export RIVER_GUIDE_OIDC_CLIENT_SECRET='${oidc_config.client_secret}'" >> ~
 echo "@reboot root . ~/.bashrc && AWS_REGION=${region} /opt/river-guide %{if tags != null}--tags ${tags} %{endif}--title '${title}' \
 --background-color='${background_color}' \
 --accent-color='${accent_color}' \
+--port='${port}' \
 %{ if oidc_config != null ~}
 --oidc-issuer='${oidc_config.issuer}' \
 --oidc-client-id='${oidc_config.client_id}' \

--- a/templates/river_guide.sh.tftpl
+++ b/templates/river_guide.sh.tftpl
@@ -10,15 +10,15 @@ chmod 755 /opt/river-guide
 echo "@reboot root AWS_REGION=${region} /opt/river-guide %{if tags != null}--tags ${tags} %{endif}--title '${title}' \
 --background-color='${background_color}' \
 --accent-color='${accent_color}' \
-%{ if oidc_config != null }
+%{ if oidc_config != null ~}
 --oidc-issuer='${oidc_config.issuer}' \
 --oidc-client-id='${oidc_config.client_id}' \
 --oidc-client-secret='${oidc_config.client_secret}' \
 --oidc-redirect-url='${oidc_config.redirect_url}' \
-%{ if oidc_config.groups != null }--oidc-groups='${oidc_config.groups}' \%{ endif }
-%{ if oidc_config.scopes != null }--oidc-scopes='${oidc_config.scopes}' \%{ endif }
-%{ if oidc_config.log_claims != null }--oidc-log-claims='${oidc_config.log_claims}' \%{ endif }
-%{ endif }" \
+%{ if oidc_config.groups != null ~}--oidc-groups='${oidc_config.groups}' \%{ endif ~}
+%{ if oidc_config.scopes != null ~}--oidc-scopes='${oidc_config.scopes}' \%{ endif ~}
+%{ if oidc_config.log_claims != null ~}--oidc-log-claims='${oidc_config.log_claims}' \%{ endif ~}
+%{ endif ~}" \
 | tee -a /etc/crontab > /dev/null
 
 # Install Cronie (not included in Amazon Linux 2023 by default)

--- a/templates/river_guide.sh.tftpl
+++ b/templates/river_guide.sh.tftpl
@@ -5,9 +5,21 @@ if [[ $(uname -m) == aarch64 ]]; then
 else
    GOARCH=amd64
 fi
-curl -L https://github.com/frgrisk/river-guide/releases/download/v0.1.1/river-guide-linux-$GOARCH --output /opt/river-guide
+curl -L https://github.com/frgrisk/river-guide/releases/download/v0.3.0/river-guide-linux-$GOARCH --output /opt/river-guide
 chmod 755 /opt/river-guide
-echo "@reboot root AWS_REGION=${region} /opt/river-guide %{if tags != null}--tags ${tags} %{endif}--title '${title}' --primary-color '${color}'" | tee -a /etc/crontab > /dev/null
+echo "@reboot root AWS_REGION=${region} /opt/river-guide %{if tags != null}--tags ${tags} %{endif}--title '${title}' \
+--background-color='${background_color}' \
+--accent-color='${accent_color}' \
+%{ if oidc_config != null }
+--oidc-issuer='${oidc_config.issuer}' \
+--oidc-client-id='${oidc_config.client_id}' \
+--oidc-client-secret='${oidc_config.client_secret}' \
+--oidc-redirect-url='${oidc_config.redirect_url}' \
+%{ if oidc_config.groups != null }--oidc-groups='${oidc_config.groups}' \%{ endif }
+%{ if oidc_config.scopes != null }--oidc-scopes='${oidc_config.scopes}' \%{ endif }
+%{ if oidc_config.log_claims != null }--oidc-log-claims='${oidc_config.log_claims}' \%{ endif }
+%{ endif }" \
+| tee -a /etc/crontab > /dev/null
 
 # Install Cronie (not included in Amazon Linux 2023 by default)
 dnf install -y cronie

--- a/variables.tf
+++ b/variables.tf
@@ -69,9 +69,32 @@ variable "river_guide_template_title" {
   default = "Environment Control"
 }
 
-variable "river_guide_template_color" {
+variable "river_guide_template_port" {
   type    = string
-  default = "#000000"
+  default = "3000"
+}
+
+variable "river_guide_template_background_color" {
+  type    = string
+  default = "#244A66"
+}
+
+variable "river_guide_template_accent_color" {
+  type    = string
+  default = "#93C30B"
+}
+
+variable "river_guide_template_oidc" {
+  type = object({
+    issuer         = string
+    client_id      = string
+    client_secret  = string
+    redirect_url   = string
+    groups         = optional(string)
+    scopes         = optional(string)
+    log_claims     = optional(string)
+  })
+  default = null
 }
 
 variable "river_guide_template_region" {

--- a/variables.tf
+++ b/variables.tf
@@ -61,7 +61,7 @@ variable "certbot_template_test_cert" {
 
 variable "river_guide_template_tags" {
   type    = string
-  default = null
+  default = ""
 }
 
 variable "river_guide_template_title" {
@@ -94,7 +94,7 @@ variable "river_guide_template_oidc" {
     scopes         = optional(string)
     log_claims     = optional(string)
   })
-  default = null
+  default = ""
 }
 
 variable "river_guide_template_region" {

--- a/variables.tf
+++ b/variables.tf
@@ -94,7 +94,15 @@ variable "river_guide_template_oidc" {
     scopes         = optional(string)
     log_claims     = optional(string)
   })
-  default = ""
+  default = {
+    issuer        = ""
+    client_id     = ""
+    client_secret = ""
+    redirect_url  = ""
+    groups        = ""
+    scopes        = ""
+    log_claims    = ""
+  }
 }
 
 variable "river_guide_template_region" {


### PR DESCRIPTION
The latest version of River Guide introduces built-in OIDC authentication, removing the need for external solutions like oauth2_proxy. This PR updates the referenced River Guide version and expands support for additional OIDC-related flags that can be passed to the binary. An example of how this can be referenced in terraform can be seen below:
```
module "river_guide_userdata_script" {
  source  = "frgrisk/user-data-scripts/aws"
  version = "0.8.0"
  river_guide_template_region = "ap-southeast-5"
  river_guide_template_tags   = "Environment=dev,RiverGuideDisplay=true"
  river_guide_template_title  = "Instance Environment Control"
  river_guide_template_oidc = {
    issuer        = "https://login.microsoftonline.com/<tenant_id>/v2.0"
    client_id     = "<client_id>"
    client_secret = "<client_secret>"
    redirect_url  = "https://river-guide-example.frgrisk.com/callback"
    log_claims    = "email,name"
  }
}

```
Additionally, a few updates have been made. The --primary-color flag has been deprecated and replaced with --background-color and --accent-color.

The MSSQL server setup script has also been updated to dynamically resolve the version of the repository to use, and the base script has been adjusted to resolve an issue where uname -i could return an unknown value.